### PR TITLE
Update ocpu url, start and end date of the chartpanel.component

### DIFF
--- a/src/app/time-series/chartpanel/chartpanel.component.ts
+++ b/src/app/time-series/chartpanel/chartpanel.component.ts
@@ -30,9 +30,9 @@ export class ChartpanelComponent implements OnInit {
   constructor (
     private shareData: TsComponentsDataShareService) {
     //set page to communicate to with "ocpusits" on server
-    // ocpu.seturl("https://terrabrasilis.ocpu.io/terrabrasilisTimeSeries/R");
+    // ocpu.seturl("https://terrabrasilis.ocpu.io/terrabrasilis-timeseries/R");
     ocpu.seturl(
-      'https://terrabrasilis.ocpu.io/terrabrasilisTimeSeries/R'
+      'https://terrabrasilis.ocpu.io/terrabrasilis-timeseries/R'
       // 'http://terrabrasilis2.dpi.inpe.br:8004/ocpu/library/terrabrasilisTimeSeries/R'
     )
     this.mySession_point = {}

--- a/src/app/time-series/controlpanel/controlpanel.component.html
+++ b/src/app/time-series/controlpanel/controlpanel.component.html
@@ -53,11 +53,11 @@
     </div>
     <div class="form-group">
       <label for="from">{{ 'timeseries.startDate' | translate }}: </label>
-      <input type="date" class="form-control" id="from" value="2008-05-04" />
+      <input type="date" class="form-control" id="from" value="2000-02-18" />
     </div>
     <div class="form-group">
       <label for="to">{{ 'timeseries.endDate' | translate }}: </label>
-      <input type="date" class="form-control" id="to" value= "{{currentDate | date:'yyyy-MM-dd'}}" />
+      <input type="date" class="form-control" id="to" value= "2019-09-30" /> <!--"{{currentDate | date:'yyyy-MM-dd'}}"-->
     </div>
 
     <button type="submit" id="submitbutton" class="btn btn-success" (click)="sendDataToChart()" [disabled]="!latitude || !longitude"> {{ 'timeseries.submit' | translate }} </button> <!-- (click)="timeseries()" -->


### PR DESCRIPTION
I saw that time series tool is enabled in the terrabrasilis platform, but when using it, is shown an error message of "Connection to OpenCPU failed: error Github App terrabrasilis/terrabrasilisTimeSeries not installed on this server. Not Found", which make impossible to use it. 
To solution this, I updated the code of the repository with terrabrasilis/terrabrasilis-timeseries package, in R, and it generated a new URL to access by opencpu service.
With this, the error message not more will be presented to the user.  